### PR TITLE
Fix web map port exposure in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     
     # Optional: Expose port if web interface is used
     ports:
-      - "8090"
+      - "8090:8090"
     
     # Health check
     healthcheck:


### PR DESCRIPTION
## Summary
- expose web map port 8090 on host to support nginx reverse proxy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc23f998c8329910039d53664743c