### PR TITLE
Ensure opt-in role does not see private location channels

### DIFF
--- a/utils/discord_permissions.py
+++ b/utils/discord_permissions.py
@@ -78,6 +78,20 @@ def build_tqe_overwrites(
     overwrites[guild.default_role] = default_overwrite
 
     if not grant_role:
+        # Explicitly deny the TQE role access so category-level permissions
+        # don't leak into private channels.
+        role_overwrite = overwrites.get(tqe_role, discord.PermissionOverwrite())
+        if channel_type == "category":
+            role_overwrite.view_channel = False
+        elif channel_type == "voice":
+            role_overwrite.view_channel = False
+            role_overwrite.connect = False
+            role_overwrite.speak = False
+        else:  # text channel
+            role_overwrite.view_channel = False
+            role_overwrite.read_messages = False
+            role_overwrite.send_messages = False
+        overwrites[tqe_role] = role_overwrite
         return overwrites
 
     # Allow the TQE role to access the channel/category


### PR DESCRIPTION
## Summary
- explicitly deny the TQE opt-in role when private channels are created so category permissions no longer leak

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda980de148329bc5f69c930aa36cf