### PR TITLE
Add NPC relationship tracking tables

### DIFF
--- a/database_sqlite_backup.py
+++ b/database_sqlite_backup.py
@@ -1558,6 +1558,32 @@ class Database:
                 FOREIGN KEY (user_id) REFERENCES characters (user_id)
             )''',
 
+            '''CREATE TABLE IF NOT EXISTS npc_relationships (
+                relationship_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                npc_id INTEGER NOT NULL,
+                npc_type TEXT NOT NULL,
+                user_id INTEGER NOT NULL,
+                relationship_score INTEGER DEFAULT 0,
+                married BOOLEAN DEFAULT 0,
+                married_at TIMESTAMP,
+                UNIQUE(npc_id, npc_type, user_id),
+                FOREIGN KEY (user_id) REFERENCES characters (user_id)
+            )''',
+
+            '''CREATE TABLE IF NOT EXISTS npc_job_assignments (
+                assignment_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id INTEGER NOT NULL,
+                npc_job_id INTEGER,
+                npc_id INTEGER NOT NULL,
+                npc_type TEXT NOT NULL,
+                user_id INTEGER NOT NULL,
+                assigned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(job_id),
+                FOREIGN KEY (user_id) REFERENCES characters (user_id),
+                FOREIGN KEY (npc_job_id) REFERENCES npc_jobs (npc_job_id),
+                FOREIGN KEY (job_id) REFERENCES jobs (job_id)
+            )''',
+
             # Enhanced NPC inventory for trading
             '''CREATE TABLE IF NOT EXISTS npc_trade_inventory (
                 trade_item_id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- add PostgreSQL DDL for npc_relationships and npc_job_assignments along with matching SQLite schema entries
- provide helpers on the Database class for reading and upserting NPC relationship rows
- supply a migration utility to backfill the new tables on legacy installs

## Testing
- python -m py_compile database.py database_sqlite_backup.py

------
https://chatgpt.com/codex/tasks/task_e_68e361599e40832982e5d1bdec009c1d