### PR TITLE
Clear NPC marriages and jobs on character death

### DIFF
--- a/cogs/character.py
+++ b/cogs/character.py
@@ -2466,6 +2466,19 @@ class CharacterCog(commands.Cog):
         self.db.execute_query("DELETE FROM character_identity WHERE user_id = %s", (user_id,))
         self.db.execute_query("DELETE FROM character_inventory WHERE user_id = %s", (user_id,))
         self.db.execute_query("DELETE FROM inventory WHERE owner_id = %s", (user_id,))
+
+        # Release any NPC marriages or assignments tied to this character so they can interact with other players
+        self.db.execute_query(
+            """UPDATE npc_relationships
+                   SET married = false,
+                       married_at = NULL
+                 WHERE user_id = %s AND married = true""",
+            (user_id,),
+        )
+        self.db.execute_query(
+            "DELETE FROM npc_job_assignments WHERE user_id = %s",
+            (user_id,),
+        )
         
         # Handle ship exchange listings - transfer to location inventory before deleting ships
         await self._handle_ship_exchange_death_cleanup(user_id)


### PR DESCRIPTION
## Summary
- clear NPC marriage flags and timestamps when a character dies so the relationship UI reflects their availability
- remove NPC job assignments tied to deceased characters to free them for future proposals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3668992588329a7cd6f2a8294e14a